### PR TITLE
Vulnerability fix: bumping cdap & hadoop version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>6.1.1</cdap.version>
-    <hadoop.version>2.3.0</hadoop.version>
+    <cdap.version>6.8.0</cdap.version>
+    <hadoop.version>2.10.2</hadoop.version>
     <hydrator.version>2.3.5</hydrator.version>
     <adwords.version>4.9.0</adwords.version>
     <guava.version>20.0</guava.version>
@@ -236,7 +236,7 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-data-pipeline</artifactId>
+      <artifactId>cdap-data-pipeline2_2.11</artifactId>
       <version>${cdap.version}</version>
       <scope>test</scope>
       <exclusions>
@@ -280,7 +280,7 @@
         <version>1.1.0</version>
         <configuration>
           <cdapArtifacts>
-            <parent>system:cdap-data-pipeline[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-pipeline[6.8.0,7.0.0-SNAPSHOT)</parent>
           </cdapArtifacts>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,10 @@
       <scope>provided</scope>
       <exclusions>
         <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>


### PR DESCRIPTION
Hadoop version 2.3.0 has transitive dependency on log4j 1.2.17 which has vulnerabilities. 

```
[INFO] io.cdap.plugin:google-ads:jar:1.0.0-SNAPSHOT
[INFO] \- org.apache.hadoop:hadoop-mapreduce-client-core:jar:2.3.0:provided
[INFO]    \- org.apache.hadoop:hadoop-yarn-common:jar:2.3.0:provided
[INFO]       \- log4j:log4j:jar:1.2.17:provided
```

This PR is to resolve the vulnerabilities by bumping hadoop to version 2.10.2 and also update cdap version to the latest version.
Maven build and all unit tests succeeded.